### PR TITLE
Sending Email on Lead Creation

### DIFF
--- a/custom/modules/Leads/AfterSaveProcesses.php
+++ b/custom/modules/Leads/AfterSaveProcesses.php
@@ -1,0 +1,52 @@
+<?php
+require_once('config.php');
+
+// Load necessary SuiteCRM files
+require_once('include/SugarPHPMailer.php');
+
+
+if (!defined('sugarEntry') || !sugarEntry) {
+  die('Not A Valid Entry Point');
+}
+
+class AfterSaveProcesses
+{
+
+
+  public function sendEmail(&$bean, $event, $arguments)
+  {
+    // Example usage
+    try {
+      $to = 'tshams80@gmail.com';
+      $subject = 'After Save Email for Lead';
+      $body = 'Something about email is not right';
+      $this->sendMail($to, $subject, $body);
+      echo 'Email sent successfully!';
+    } catch (Exception $e) {
+      echo 'Error sending email: ' . $e->getMessage();
+    }
+  }
+
+
+
+  // Load SuiteCRM configuration
+
+  // Function to send email using system email account
+  function sendMail($to, $subject, $body) {
+    global $sugar_config;
+
+    $mail = new SugarPHPMailer();
+    $mail->setMailerForSystem();
+    $mail->From = $sugar_config['email_from_address'];
+    $mail->FromName = $sugar_config['email_from_name'];
+    $mail->addAddress($to);
+    $mail->Subject = $subject;
+    $mail->Body = $body;
+
+    if (!$mail->send()) {
+      throw new Exception($mail->ErrorInfo);
+    }
+  }
+
+
+}

--- a/custom/modules/Leads/logic_hooks.php
+++ b/custom/modules/Leads/logic_hooks.php
@@ -1,15 +1,15 @@
 <?php
-// Do not store anything in this file that is not part of the array or the hook version.  This file will	
-// be automatically rebuilt in the future. 
- $hook_version = 1; 
-$hook_array = Array(); 
-// position, file, function 
-$hook_array['before_save'] = Array(); 
-$hook_array['before_save'][] = Array(1, 'Leads push feed', 'modules/Leads/SugarFeeds/LeadFeed.php','LeadFeed', 'pushFeed'); 
-$hook_array['before_save'][] = Array(77, 'updateGeocodeInfo', 'modules/Leads/LeadsJjwg_MapsLogicHook.php','LeadsJjwg_MapsLogicHook', 'updateGeocodeInfo'); 
-$hook_array['after_save'] = Array(); 
-$hook_array['after_save'][] = Array(77, 'updateRelatedMeetingsGeocodeInfo', 'modules/Leads/LeadsJjwg_MapsLogicHook.php','LeadsJjwg_MapsLogicHook', 'updateRelatedMeetingsGeocodeInfo'); 
+// Do not store anything in this file that is not part of the array or the hook version.  This file will
+// be automatically rebuilt in the future.
+ $hook_version = 1;
+$hook_array = Array();
+// position, file, function
+$hook_array['before_save'] = Array();
+$hook_array['before_save'][] = Array(1, 'Leads push feed', 'modules/Leads/SugarFeeds/LeadFeed.php','LeadFeed', 'pushFeed');
+$hook_array['before_save'][] = Array(77, 'updateGeocodeInfo', 'modules/Leads/LeadsJjwg_MapsLogicHook.php','LeadsJjwg_MapsLogicHook', 'updateGeocodeInfo');
+$hook_array['after_save'] = Array();
+$hook_array['after_save'][] = Array(77, 'updateRelatedMeetingsGeocodeInfo', 'modules/Leads/LeadsJjwg_MapsLogicHook.php','LeadsJjwg_MapsLogicHook', 'updateRelatedMeetingsGeocodeInfo');
 
-
+$hook_array['after_save'][] = Array(1,'sendEmail','custom/modules/Leads/AfterSaveProcesses.php','AfterSaveProcesses','sendEmail');
 
 ?>

--- a/index.php
+++ b/index.php
@@ -42,6 +42,7 @@ if (!defined('sugarEntry')) {
     define('sugarEntry', true);
 }
 
+ini_set('display_errors','On');
 include 'include/MVC/preDispatch.php';
 $startTime = microtime(true);
 require_once 'include/entryPoint.php';


### PR DESCRIPTION
* **New file added for Leads processing**
A new file named AfterSaveProcesses.php was created to handle specific actions in the Leads module.

* **Logic hooks update for Leads module**
The logic hooks for the Leads module have been modified to send an email using the sendEmail() function from the AfterSaveProcesses class when a Lead record is saved.

* **Display errors enabled in index.php**
The index.php file was updated to show PHP error messages, which helps identify issues during script execution.

Why did the developer add the AfterSaveProcesses.php file and update the logic hooks in the Leads module? Because they wanted to _lead_ by example and make sure every saved Lead gets an _emailed_ invitation to the party! 🥳 📧